### PR TITLE
fix(makefile): repair covdata guard, use compose v2, run argen via go run

### DIFF
--- a/docs/GO-VERSION-POLICY.md
+++ b/docs/GO-VERSION-POLICY.md
@@ -95,7 +95,7 @@ Workflow `.github/workflows/go-version-check.yml` запускает скрип�
 
 ## Что **нельзя** делать
 
-- `go tool <X>` в шаблонах `*.tmpl` для `<X>` не из minimal-набора (см. список выше). Если очень нужно — добавить preflight check `go tool <X> help >/dev/null 2>&1` с понятным WARN-сообщением, **без** маскировки через `2>/dev/null || true`.
+- `go tool <X>` в шаблонах `*.tmpl` для `<X>` не из minimal-набора (см. список выше). Если очень нужно — добавить preflight check `go tool -n <X> >/dev/null 2>&1` с понятным WARN-сообщением, **без** маскировки через `2>/dev/null || true`. Именно `-n` (печатает путь до тула, exit 0 если есть, exit 2 + `no such tool` если нет): пробовать `go tool <X> help` нельзя — селектор `help` есть не у всех тулов (`go tool covdata help` → exit 2 даже на полном toolchain), такая проба всегда рапортует «тула нет».
 - Bump `go <X>` в `go.mod` без согласованного rationale.
 - Подъём `tools.golang_version` в `project.yaml` тестовых конфигов «для синхронизации с основной версией». Тестовые конфиги — отдельная история, цельтесь в реальный минимум.
 

--- a/internal/pkg/templater/embedded/templates/main/Makefile.tmpl
+++ b/internal/pkg/templater/embedded/templates/main/Makefile.tmpl
@@ -189,7 +189,7 @@ test-integration-with-deps: test-int-up-deps test-integration
 .PHONY: test-int-up-deps
 test-int-up-deps:
 	@echo "Up testing dependencies: \n"
-	docker-compose up -d --build --force-recreate wiremock
+	docker compose up -d --build --force-recreate wiremock
 	@echo "Successful up testing dependencies"
 
 # Run unit testing (excludes GOAT integration tests)
@@ -507,7 +507,7 @@ generate-ogen:
 # Generate activerecord files from all openapi specifications
 .PHONY: generate-argen
 generate-argen:
-	argen --path ./internal/pkg/model/repository --declaration "decl" --destination "cmpl" --schema_path etc/database
+	GOPRIVATE=$(GOPRIVATE) go run github.com/Educentr/go-activerecord/v3/cmd/argen@$(ARGENVERSION) --path ./internal/pkg/model/repository --declaration "decl" --destination "cmpl" --schema_path etc/database
 
 .PHONY: install-argen
 install-argen:
@@ -690,7 +690,7 @@ goat-tests-{{ $a.Name }}: build_for_test-{{ $a.Name }}{{ if not $a.UseEnvs }} ge
 	export GOAT_DISABLE_STDOUT=true \
 	&& export GOCOVERDIR=$(COVERAGE_DIR) \
 	&& go test -count=1 ./tests/{{ $a.Name }}
-	@if ! go tool covdata help >/dev/null 2>&1; then \
+	@if ! go tool -n covdata >/dev/null 2>&1; then \
 		echo "WARN: 'go tool covdata' unavailable in current Go toolchain — integration coverage report skipped."; \
 		echo "      Cause: locally installed Go is older than the version declared in go.mod,"; \
 		echo "      so GOTOOLCHAIN=auto pulled a minimal toolchain that does not include covdata."; \
@@ -713,7 +713,7 @@ goat-tests-{{ $a.Name }}-verbose: build_for_test-{{ $a.Name }}{{ if not $a.UseEn
 	@rm -rf $(COVERAGE_DIR)
 	@mkdir -p $(COVERAGE_DIR)
 	GOCOVERDIR=$(COVERAGE_DIR) go test -count=1 -v ./tests/{{ $a.Name }}/...
-	@if ! go tool covdata help >/dev/null 2>&1; then \
+	@if ! go tool -n covdata >/dev/null 2>&1; then \
 		echo "WARN: 'go tool covdata' unavailable in current Go toolchain — integration coverage report skipped."; \
 		echo "      Cause: locally installed Go is older than the version declared in go.mod,"; \
 		echo "      so GOTOOLCHAIN=auto pulled a minimal toolchain that does not include covdata."; \


### PR DESCRIPTION
Closes #30.

Three independent defects in `internal/pkg/templater/embedded/templates/main/Makefile.tmpl`, plus the doc recipe that caused the first one.

## 1. covdata guard never ran the coverage branch (`:693`, `:716`)

`go tool covdata help` is not a valid probe — covdata has no `help` selector and exits 2 even on a full toolchain:

```console
$ go version
go version go1.26.4 darwin/arm64
$ go tool covdata help >/dev/null 2>&1; echo $?
2
$ go tool covdata 2>&1 | head -1
error: missing command selector
```

So `! (exit 2)` was always true, the `covdata textfmt` → `cover -html` branch never executed on any machine, and integration coverage was silently dropped behind a WARN about a minimal toolchain that was not the actual cause.

Fixed by probing with `go tool -n covdata` — a real zero-exit probe:

| command | exit |
|---|---|
| `go tool -n covdata` | 0 (prints tool path) |
| `go tool -n covdataXXX` | 2 (`go: no such tool`) |

This keeps the branch order and the WARN text unchanged, and does not depend on the toolchain's error wording. The bug was duplicated in `goat-tests-<app>` and `goat-tests-<app>-verbose`; both are fixed.

Verified end-to-end on real coverage data (build `-cover`, run with `GOCOVERDIR`, then execute the guard): the new probe takes the ELSE branch and emits a non-empty profile, the old probe takes the WARN-skip branch.

## 2. `test-int-up-deps` used Compose v1 (`:192`)

`docker-compose` (v1, EOL July 2023) → `docker compose`. Every other target in the template (`:380-396`) was already on v2.

## 3. `generate-argen` required a preinstalled binary (`:510`)

Bare `argen` on PATH meant `make generate` failed in a clean image with only `go`, while the sibling `generate-ogen` was already self-contained via `go run …@$(OGENVERSION)`. Brought to the same pattern; `ARGENVERSION` was already declared (`:26`). `GOPRIVATE` is kept for parity with `install-argen`, which stays as an optional convenience target and leaves the mandatory `make generate` chain.

Verified: `go run github.com/Educentr/go-activerecord/v3/cmd/argen@v3.1.22 --help` resolves and runs without auth.

## 4. `docs/GO-VERSION-POLICY.md` — the source of #1

The "Что нельзя делать" section prescribed `go tool <X> help >/dev/null 2>&1` as *the* recommended preflight check. The template was just its first consumer, so the doc is updated to `go tool -n <X>` with a note on why `help` is not a universal selector — otherwise the next `go tool` in a template repeats the bug.

## Verification

- Generated projects from `test/docker-integration/configs/rest-only` and `rest-envs-goat`; both Makefiles parse, `make -n test-int-up-deps` emits `docker compose up …`, `make -n goat-tests-api` expands the guard with `go tool -n covdata`.
- `go test ./test/... -count=1` passes (`test/docker-integration` skips — needs `TEST_IMAGE`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)